### PR TITLE
Solve bug on runIfAlpha with 3 arguments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
 		<dependency>
 			<groupId>org.apache.curator</groupId>
 			<artifactId>curator-recipes</artifactId>
-			<version>2.6.0</version>
+			<version>2.8.0</version>
 		</dependency>
 
 	</dependencies>

--- a/src/main/java/com/weirdbob/alphadog/AlphaDog.java
+++ b/src/main/java/com/weirdbob/alphadog/AlphaDog.java
@@ -11,6 +11,7 @@ import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.recipes.locks.InterProcessSemaphoreMutex;
 import org.apache.curator.retry.ExponentialBackoffRetry;
+import org.apache.zookeeper.KeeperException.NoNodeException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,7 +72,12 @@ public class AlphaDog implements Closeable {
 		Preconditions.checkArgument(!Strings.isNullOrEmpty(lockName), "lockName is not optionnal");
 		String lockPath = getLockPath(lockName);
         try {
-        	byte[] data = client.getData().forPath(lockPath);
+            byte[] data;
+            try {
+                data = client.getData().forPath(lockPath);
+            } catch(NoNodeException e) {
+                data = null;
+            }
         	if(data == null || data.length == 0) {
         		// never launched -> set last run to epoch
         		data = new byte[]{0,0,0,0,0,0,0,0};


### PR DESCRIPTION
- Update curator-recipes version
- Solve bug when using runIfAlpha (with 3 parameters) for the first time

Indeed the node does not exists the first time and an NoNodeException is thrown.
